### PR TITLE
Remove _Subclass from defaultAlias

### DIFF
--- a/src/main/java/net/kautler/command/api/Command.java
+++ b/src/main/java/net/kautler/command/api/Command.java
@@ -90,7 +90,7 @@ public interface Command<M> {
         if (className.isEmpty()) {
             className = clazz.getTypeName().substring(clazz.getPackage().getName().length() + 1);
         }
-        String defaultAlias = className.replaceAll("(?i)^(?:Command|Cmd)|(?:Command|Cmd)$", "");
+        String defaultAlias = className.replaceAll("(?i)^(?:Command|Cmd)|(?:Command|Cmd)|(?:_Subclass)$", "");
         defaultAlias = defaultAlias.replaceFirst("^.", Character.toString(toLowerCase(defaultAlias.charAt(0))));
         return singletonList(defaultAlias);
     }


### PR DESCRIPTION
When being used in [Quarkus](https://quarkus.io/), the class name is returned with `_Subclass` appended to the name. This causes the command to not be found. This adds a section to the replaceAll regex to remove the `_Subclass` from the string.